### PR TITLE
fix - reset completed state on end to support use of same button in multiple steps

### DIFF
--- a/Button_Lever/Runtime/Conditions/GripButtonConditionActiveProcess.cs
+++ b/Button_Lever/Runtime/Conditions/GripButtonConditionActiveProcess.cs
@@ -59,6 +59,7 @@ namespace VRBuilder.Community
         public override void End()
         {
             XRGripButton button = Data.Target.Value.GameObject.GetComponent<XRGripButton>();
+            Data.IsCompleted = false;  // reset completed state, otherwise it would stay completed when using in a loop...
             if (button != null)
             {
                 button.onPress.RemoveListener(OnButtonPressed);

--- a/Button_Lever/Runtime/Conditions/PushButtonConditionActiveProcess.cs
+++ b/Button_Lever/Runtime/Conditions/PushButtonConditionActiveProcess.cs
@@ -56,6 +56,7 @@ namespace VRBuilder.Community
         public override void End()
         {
             XRPushButton button = Data.Target.Value.GameObject.GetComponent<XRPushButton>();
+            Data.IsCompleted = false;  // reset completed state, otherwise it would stay completed when using in a loop...
             if (button != null)
             {
                 button.onPress.RemoveListener(OnButtonPressed);


### PR DESCRIPTION
use of the sane buttons in multiple steps was not possible, since completed state was still true after pushed once in a process.
This fix resets the completed state after step has been processed in End() method